### PR TITLE
UMD, package.json, and proper deinitialization 

### DIFF
--- a/dataTables.rowsGroup.js
+++ b/dataTables.rowsGroup.js
@@ -38,7 +38,37 @@
  *     
  */
 
-(function($){
+(function( factory ) {
+	"use strict";
+
+	if ( typeof define === 'function' && define.amd ) {
+		// AMD
+		define( ['jquery'], function ( $ ) {
+			return factory( $, window, document );
+		} );
+	}
+	else if ( typeof exports === 'object' ) {
+		// CommonJS
+		module.exports = function (root, $) {
+			if ( ! root ) {
+				root = window;
+			}
+
+			if ( ! $ ) {
+				$ = typeof window !== 'undefined' ?
+					require('jquery') :
+					require('jquery')( root );
+			}
+
+			return factory( $, root, root.document );
+		};
+	}
+	else {
+		// Browser
+		factory( jQuery, window, document );
+	}
+}
+(function($, window, document){
 
 ShowedDataSelectorModifier = {
 	order: 'current',
@@ -266,7 +296,7 @@ $(document).on( 'init.dt', function ( e, settings ) {
 	}
 } );
 
-}(jQuery));
+}));
 
 /*
 

--- a/dataTables.rowsGroup.js
+++ b/dataTables.rowsGroup.js
@@ -92,7 +92,7 @@ var RowsGroup = function ( dt, columnsForGrouping )
 	this.order = []
 	
 	var self = this;
-	dt.on('order.dt', function ( e, settings) {
+	dt.on('order.dt.rowsGroup', function ( e, settings) {
 		if (!self.orderOverrideNow) {
 			self.orderOverrideNow = true;
 			self._updateOrderAndDraw()
@@ -101,33 +101,37 @@ var RowsGroup = function ( dt, columnsForGrouping )
 		}
 	})
 	
-	dt.on('preDraw.dt', function ( e, settings) {
+	dt.on('preDraw.dt.rowsGroup', function ( e, settings) {
 		if (self.mergeCellsNeeded) {
 			self.mergeCellsNeeded = false;
 			self._mergeCells()
 		}
 	})
 	
-	dt.on('column-visibility.dt', function ( e, settings) {
+	dt.on('column-visibility.dt.rowsGroup', function ( e, settings) {
 		self.mergeCellsNeeded = true;
 	})
 
-	dt.on('search.dt', function ( e, settings) {
+	dt.on('search.dt.rowsGroup', function ( e, settings) {
 		// This might to increase the time to redraw while searching on tables
 		//   with huge shown columns
 		self.mergeCellsNeeded = true;
 	})
 
-	dt.on('page.dt', function ( e, settings) {
+	dt.on('page.dt.rowsGroup', function ( e, settings) {
 		self.mergeCellsNeeded = true;
 	})
 
-	dt.on('length.dt', function ( e, settings) {
+	dt.on('length.dt.rowsGroup', function ( e, settings) {
 		self.mergeCellsNeeded = true;
 	})
 
-	dt.on('xhr.dt', function ( e, settings) {
+	dt.on('xhr.dt.rowsGroup', function ( e, settings) {
 		self.mergeCellsNeeded = true;
+	})
+
+	dt.on('destroy.dt.rowsGroup', function ( e ) {
+		dt.off('.rowsGroup');
 	})
 
 	this._updateOrderAndDraw();
@@ -271,7 +275,7 @@ $.fn.dataTable.RowsGroup = RowsGroup;
 $.fn.DataTable.RowsGroup = RowsGroup;
 
 // Automatic initialisation listener
-$(document).on( 'init.dt', function ( e, settings ) {
+$(document).on( 'init.dt.rowsGroup', function ( e, settings ) {
 	if ( e.namespace !== 'dt' ) {
 		return;
 	}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "datatables-rowsgroup",
+  "version": "1.0.0",
+  "description": "The Datatables feature plugin that groups rows (merge cells vertically) in according to specified columns",
+  "main": "dataTables.rowsGroup.js",
+  "repository": "git@github.com:futpib/datatables-rowsgroup.git",
+  "license": "MIT"
+}

--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
   "description": "The Datatables feature plugin that groups rows (merge cells vertically) in according to specified columns",
   "main": "dataTables.rowsGroup.js",
   "repository": "git@github.com:futpib/datatables-rowsgroup.git",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "jquery": ">=1.7"
+  }
 }


### PR DESCRIPTION
Motivations:
* UMD - kinda obvious
* * Needed to use this plugin in CommonJS environment
* package.json
* * Browserify can not load a module without package.json (I expect the same is true for webpack)
* deinitialization, event namespacing and unbinding
* * When datatable is destroyed, rowsGroup failed to unbind it's event, and, if later you instantiate datable on the same DOM element, you get double event handling from both old and new rowsGroup instances