### PR TITLE
Overhaul: ES6, ESLint, package.json, some smaller fixes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+    "extends": "airbnb",
+    "env": {
+        "es6": true,
+        "browser": true,
+        "commonjs": true
+    },
+    "rules": {
+        "indent":               ["error", 4, { "outerIIFEBody": 0 }],
+        "no-trailing-spaces":   ["error", { "skipBlankLines": true }],
+        "no-underscore-dangle": ["error", { "allowAfterThis": true }],
+        "no-mixed-operators":   ["error", { "allowSamePrecedence": true }]
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules/
+/package-lock.json

--- a/anotherExample.html
+++ b/anotherExample.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+	<meta charset="utf-8">
     <link rel="stylesheet" href="http://cdn.datatables.net/1.10.7/css/jquery.dataTables.min.css">
     <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
 

--- a/dataTables.rowsGroup.js
+++ b/dataTables.rowsGroup.js
@@ -38,234 +38,225 @@
  *     
  */
 
-(function($){
+/* eslint-disable padded-blocks */
+(function init($) {
+/* eslint-enable padded-blocks */
 
-ShowedDataSelectorModifier = {
-	order: 'current',
-	page: 'current',
-	search: 'applied',
+
+function toggleDirection(dir) {
+    return dir === 'asc' ? 'desc' : 'asc';
 }
 
-GroupedColumnsOrderDir = 'asc';
+const ShowedDataSelectorModifier = {
+    order: 'current',
+    page: 'current',
+    search: 'applied',
+};
+
+const GroupedColumnsOrderDir = 'asc';
 
 
 /*
  * columnsForGrouping: array of DTAPI:cell-selector for columns for which rows grouping is applied
  */
-var RowsGroup = function ( dt, columnsForGrouping )
-{
-	this.table = dt.table();
-	this.columnsForGrouping = columnsForGrouping;
-	 // set to True when new reorder is applied by RowsGroup to prevent order() looping
-	this.orderOverrideNow = false;
-	this.mergeCellsNeeded = false; // merge after init
-	this.order = []
-	
-	var self = this;
-	dt.on('order.dt', function ( e, settings) {
-		if (!self.orderOverrideNow) {
-			self.orderOverrideNow = true;
-			self._updateOrderAndDraw()
-		} else {
-			self.orderOverrideNow = false;
-		}
-	})
-	
-	dt.on('preDraw.dt', function ( e, settings) {
-		if (self.mergeCellsNeeded) {
-			self.mergeCellsNeeded = false;
-			self._mergeCells()
-		}
-	})
-	
-	dt.on('column-visibility.dt', function ( e, settings) {
-		self.mergeCellsNeeded = true;
-	})
+class RowsGroup {
+    constructor(dt, columnsForGrouping) {
+        this.table = dt.table();
+        this.columnsForGrouping = columnsForGrouping;
+        // set to True when new reorder is applied by RowsGroup to prevent order() looping
+        this.orderOverrideNow = false;
+        this.mergeCellsNeeded = false; // merge after init
+        this.order = [];
+        
+        dt.on('order.dt', () => {
+            if (!this.orderOverrideNow) {
+                this.orderOverrideNow = true;
+                this._updateOrderAndDraw();
+            } else {
+                this.orderOverrideNow = false;
+            }
+        });
+        
+        dt.on('preDraw.dt', () => {
+            if (this.mergeCellsNeeded) {
+                this.mergeCellsNeeded = false;
+                this._mergeCells();
+            }
+        });
+        
+        dt.on('column-visibility.dt', () => {
+            this.mergeCellsNeeded = true;
+        });
 
-	dt.on('search.dt', function ( e, settings) {
-		// This might to increase the time to redraw while searching on tables
-		//   with huge shown columns
-		self.mergeCellsNeeded = true;
-	})
+        dt.on('search.dt', () => {
+            // This might to increase the time to redraw while searching on tables
+            //   with huge shown columns
+            this.mergeCellsNeeded = true;
+        });
 
-	dt.on('page.dt', function ( e, settings) {
-		self.mergeCellsNeeded = true;
-	})
+        dt.on('page.dt', () => {
+            this.mergeCellsNeeded = true;
+        });
 
-	dt.on('length.dt', function ( e, settings) {
-		self.mergeCellsNeeded = true;
-	})
+        dt.on('length.dt', () => {
+            this.mergeCellsNeeded = true;
+        });
 
-	dt.on('xhr.dt', function ( e, settings) {
-		self.mergeCellsNeeded = true;
-	})
+        dt.on('xhr.dt', () => {
+            this.mergeCellsNeeded = true;
+        });
 
-	this._updateOrderAndDraw();
-	
-/* Events sequence while Add row (also through Editor)
- * addRow() function
- *   draw() function
- *     preDraw() event
- *       mergeCells() - point 1
- *     Appended new row breaks visible elements because the mergeCells() on previous step doesn't apllied to already processing data
- *   order() event
- *     _updateOrderAndDraw()
- *       preDraw() event
- *         mergeCells()
- *       Appended new row now has properly visibility as on current level it has already applied changes from first mergeCells() call (point 1)
- *   draw() event
- */
-};
+        this._updateOrderAndDraw();
 
+        /* Events sequence while Add row (also through Editor)
+         * addRow() function
+         *   draw() function
+         *     preDraw() event
+         *       mergeCells() - point 1
+         *     Appended new row breaks visible elements because the mergeCells()
+         *     on previous step doesn't apply to already processing data
+         *   order() event
+         *     _updateOrderAndDraw()
+         *       preDraw() event
+         *         mergeCells()
+         *       Appended new row now has properly visibility as on current level
+         *       it has already applied changes from first mergeCells() call (point 1)
+         *   draw() event
+         */
+    }
 
-RowsGroup.prototype = {
-	setMergeCells: function(){
-		this.mergeCellsNeeded = true;
-	},
+    setMergeCells() {
+        this.mergeCellsNeeded = true;
+    }
 
-	mergeCells: function()
-	{
-		this.setMergeCells();
-		this.table.draw();
-	},
+    mergeCells() {
+        this.setMergeCells();
+        this.table.draw();
+    }
 
-	_getOrderWithGroupColumns: function (order, groupedColumnsOrderDir)
-	{
-		if (groupedColumnsOrderDir === undefined)
-			groupedColumnsOrderDir = GroupedColumnsOrderDir
-			
-		var self = this;
-		var groupedColumnsIndexes = this.columnsForGrouping.map(function(columnSelector){
-			return self.table.column(columnSelector).index()
-		})
-		var groupedColumnsKnownOrder = order.filter(function(columnOrder){
-			return groupedColumnsIndexes.indexOf(columnOrder[0]) >= 0
-		})
-		var nongroupedColumnsOrder = order.filter(function(columnOrder){
-			return groupedColumnsIndexes.indexOf(columnOrder[0]) < 0
-		})
-		var groupedColumnsKnownOrderIndexes = groupedColumnsKnownOrder.map(function(columnOrder){
-			return columnOrder[0]
-		})
-		var groupedColumnsOrder = groupedColumnsIndexes.map(function(iColumn){
-			var iInOrderIndexes = groupedColumnsKnownOrderIndexes.indexOf(iColumn)
-			if (iInOrderIndexes >= 0)
-				return [iColumn, groupedColumnsKnownOrder[iInOrderIndexes][1]]
-			else
-				return [iColumn, groupedColumnsOrderDir]
-		})
-		
-		groupedColumnsOrder.push.apply(groupedColumnsOrder, nongroupedColumnsOrder)
-		return groupedColumnsOrder;
-	},
+    _getOrderWithGroupColumns(order, groupedColumnsOrderDir = GroupedColumnsOrderDir) {
+        const groupedColumnsIndexes = this.columnsForGrouping.map(
+            columnSelector => this.table.column(columnSelector).index());
+        const groupedColumnsKnownOrder = order.filter(
+            columnOrder => groupedColumnsIndexes.indexOf(columnOrder[0]) >= 0);
+        const nongroupedColumnsOrder = order.filter(
+            columnOrder => groupedColumnsIndexes.indexOf(columnOrder[0]) < 0);
+        const groupedColumnsKnownOrderIndexes = groupedColumnsKnownOrder.map(
+            columnOrder => columnOrder[0]);
+        const groupedColumnsOrder = groupedColumnsIndexes.map((iColumn) => {
+            const iInOrderIndexes = groupedColumnsKnownOrderIndexes.indexOf(iColumn);
+            if (iInOrderIndexes >= 0) {
+                return [iColumn, groupedColumnsKnownOrder[iInOrderIndexes][1]];
+            }
+            return [iColumn, groupedColumnsOrderDir];
+        });
+        
+        groupedColumnsOrder.push(...nongroupedColumnsOrder);
+        return groupedColumnsOrder;
+    }
  
-	// Workaround: the DT reset ordering to 'asc' from multi-ordering if user order on one column (without shift)
-	//   but because we always has multi-ordering due to grouped rows this happens every time
-	_getInjectedMonoSelectWorkaround: function(order)
-	{
-		if (order.length === 1) {
-			// got mono order - workaround here
-			var orderingColumn = order[0][0]
-			var previousOrder = this.order.map(function(val){
-				return val[0]
-			})
-			var iColumn = previousOrder.indexOf(orderingColumn);
-			if (iColumn >= 0) {
-				// assume change the direction, because we already has that in previos order
-				return [[orderingColumn, this._toogleDirection(this.order[iColumn][1])]]
-			} // else This is the new ordering column. Proceed as is.
-		} // else got milti order - work normal
-		return order;
-	},
-	
-	_mergeCells: function()
-	{
-		var columnsIndexes = this.table.columns(this.columnsForGrouping, ShowedDataSelectorModifier).indexes().toArray()
-		var showedRowsCount = this.table.rows(ShowedDataSelectorModifier)[0].length 
-		this._mergeColumn(0, showedRowsCount - 1, columnsIndexes)
-	},
-	
-	// the index is relative to the showed data
-	//    (selector-modifier = {order: 'current', page: 'current', search: 'applied'}) index
-	_mergeColumn: function(iStartRow, iFinishRow, columnsIndexes)
-	{
-		var columnsIndexesCopy = columnsIndexes.slice()
-		currentColumn = columnsIndexesCopy.shift()
-		currentColumn = this.table.column(currentColumn, ShowedDataSelectorModifier)
-		
-		var columnNodes = currentColumn.nodes()
-		var columnValues = currentColumn.data()
-		
-		var newSequenceRow = iStartRow,
-			iRow;
-		for (iRow = iStartRow + 1; iRow <= iFinishRow; ++iRow) {
-			
-			if (columnValues[iRow] === columnValues[newSequenceRow]) {
-				$(columnNodes[iRow]).hide()
-			} else {
-				$(columnNodes[newSequenceRow]).show()
-				$(columnNodes[newSequenceRow]).attr('rowspan', (iRow-1) - newSequenceRow + 1)
-				
-				if (columnsIndexesCopy.length > 0)
-					this._mergeColumn(newSequenceRow, (iRow-1), columnsIndexesCopy)
-				
-				newSequenceRow = iRow;
-			}
-			
-		}
-		$(columnNodes[newSequenceRow]).show()
-		$(columnNodes[newSequenceRow]).attr('rowspan', (iRow-1)- newSequenceRow + 1)
-		if (columnsIndexesCopy.length > 0)
-			this._mergeColumn(newSequenceRow, (iRow-1), columnsIndexesCopy)
-	},
-	
-	_toogleDirection: function(dir)
-	{
-		return dir == 'asc'? 'desc': 'asc';
-	},
- 
-	_updateOrderAndDraw: function()
-	{
-		this.mergeCellsNeeded = true;
-		
-		var currentOrder = this.table.order();
-		currentOrder = this._getInjectedMonoSelectWorkaround(currentOrder);
-		this.order = this._getOrderWithGroupColumns(currentOrder)
-		this.table.order($.extend(true, Array(), this.order))
-		this.table.draw()
-	},
-};
+    /* Workaround: the DT reset ordering to 'asc' from multi-ordering
+     * if user order on one column (without shift)
+     * but because we always have multi-ordering due to grouped rows
+     * this happens every time
+     */
+    _getInjectedMonoSelectWorkaround(order) {
+        if (order.length === 1) {
+            // got mono order - workaround here
+            const orderingColumn = order[0][0];
+            const previousOrder = this.order.map(val => val[0]);
+            const iColumn = previousOrder.indexOf(orderingColumn);
+            if (iColumn >= 0) {
+                // assume change the direction, because we already has that in previos order
+                return [[orderingColumn, toggleDirection(this.order[iColumn][1])]];
+            } // else This is the new ordering column. Proceed as is.
+        } // else got milti order - work normal
+        return order;
+    }
+    
+    _mergeCells() {
+        const columnsIndexes = this.table
+            .columns(this.columnsForGrouping, ShowedDataSelectorModifier)
+            .indexes().toArray();
+        const showedRowsCount = this.table.rows(ShowedDataSelectorModifier)[0].length;
+        this._mergeColumn(0, showedRowsCount - 1, columnsIndexes);
+    }
+    
+    // the index is relative to the showed data
+    //    (selector-modifier = {order: 'current', page: 'current', search: 'applied'}) index
+    _mergeColumn(iStartRow, iFinishRow, columnsIndexes) {
+        const columnsIndexesCopy = columnsIndexes.slice();
+        let currentColumn = columnsIndexesCopy.shift();
+        currentColumn = this.table.column(currentColumn, ShowedDataSelectorModifier);
+        
+        const columnNodes = currentColumn.nodes();
+        const columnValues = currentColumn.data();
+        
+        let newSequenceRow = iStartRow;
+        for (let iRow = iStartRow + 1; iRow <= iFinishRow; iRow += 1) {
+            if (columnValues[iRow] === columnValues[newSequenceRow]) {
+                $(columnNodes[iRow]).hide();
+            } else {
+                $(columnNodes[newSequenceRow]).show();
+                $(columnNodes[newSequenceRow]).attr('rowspan', (iRow - 1) - newSequenceRow + 1);
+                
+                if (columnsIndexesCopy.length > 0) {
+                    this._mergeColumn(newSequenceRow, (iRow - 1), columnsIndexesCopy);
+                }
+                
+                newSequenceRow = iRow;
+            }
+        }
+        $(columnNodes[newSequenceRow]).show();
+        $(columnNodes[newSequenceRow]).attr('rowspan', iFinishRow - newSequenceRow + 1);
+        if (columnsIndexesCopy.length > 0) {
+            this._mergeColumn(newSequenceRow, iFinishRow, columnsIndexesCopy);
+        }
+    }
+    
+    _updateOrderAndDraw() {
+        this.mergeCellsNeeded = true;
+        
+        let currentOrder = this.table.order();
+        currentOrder = this._getInjectedMonoSelectWorkaround(currentOrder);
+        this.order = this._getOrderWithGroupColumns(currentOrder);
+        this.table.order($.extend(true, [], this.order));
+        this.table.draw();
+    }
+}
 
-
+/* eslint-disable no-param-reassign */
 if ($.fn.dataTable) $.fn.dataTable.RowsGroup = RowsGroup;
 if ($.fn.DataTable) $.fn.DataTable.RowsGroup = RowsGroup;
+/* eslint-enable no-param-reassign */
 
 // Automatic initialisation listener
-$(document).on( 'init.dt', function ( e, settings ) {
-	if ( e.namespace !== 'dt' ) {
-		return;
-	}
+$(document).on('init.dt', (e, settings) => {
+    if (e.namespace !== 'dt') {
+        return;
+    }
 
-	var api = new $.fn.dataTable.Api( settings );
-	
-	if ( settings.oInit.rowsGroup ||
-		 $.fn.dataTable.defaults.rowsGroup )
-	{
-		options = settings.oInit.rowsGroup?
-			settings.oInit.rowsGroup:
-			$.fn.dataTable.defaults.rowsGroup;
-		var rowsGroup = new RowsGroup( api, options );
-		$.fn.dataTable.Api.register( 'rowsgroup.update()', function () {
-			rowsGroup.mergeCells();
-			return this;
-		} );
-		$.fn.dataTable.Api.register( 'rowsgroup.updateNextDraw()', function () {
-			rowsGroup.setMergeCells();
-			return this;
-		} );
-	}
-} );
+    const api = new $.fn.dataTable.Api(settings);
+    
+    if (settings.oInit.rowsGroup ||
+         $.fn.dataTable.defaults.rowsGroup) {
+        const options = settings.oInit.rowsGroup ?
+            settings.oInit.rowsGroup :
+            $.fn.dataTable.defaults.rowsGroup;
+        const rowsGroup = new RowsGroup(api, options);
+        $.fn.dataTable.Api.register('rowsgroup.update()', function update() {
+            rowsGroup.mergeCells();
+            return this;
+        });
+        $.fn.dataTable.Api.register('rowsgroup.updateNextDraw()', function updateNextDraw() {
+            rowsGroup.setMergeCells();
+            return this;
+        });
+    }
+});
 
+
+/* eslint-disable-line padded-blocks */
 }(
     (typeof require === 'function')
         ? require('jQuery')
@@ -274,16 +265,20 @@ $(document).on( 'init.dt', function ( e, settings ) {
 
 /*
 
-TODO: Provide function which determines the all <tr>s and <td>s with "rowspan" html-attribute is parent (groupped) for the specified <tr> or <td>. To use in selections, editing or hover styles.
+TODO: Provide function which determines the all <tr>s and <td>s with "rowspan"
+      html-attribute is parent (groupped) for the specified <tr> or <td>.
+      To use in selections, editing or hover styles.
 
 TODO: Feature
 Use saved order direction for grouped columns
-	Split the columns into grouped and ungrouped.
-	
-	user = grouped+ungrouped
-	grouped = grouped
-	saved = grouped+ungrouped
-	
-	For grouped uses following order: user -> saved (because 'saved' include 'grouped' after first initialisation). This should be done with saving order like for 'groupedColumns'
-	For ungrouped: uses only 'user' input ordering
+    Split the columns into grouped and ungrouped.
+    
+    user = grouped+ungrouped
+    grouped = grouped
+    saved = grouped+ungrouped
+    
+    For grouped uses following order: user -> saved
+    (because 'saved' include 'grouped' after first initialisation).
+    This should be done with saving order like for 'groupedColumns'
+    For ungrouped: uses only 'user' input ordering
 */

--- a/dataTables.rowsGroup.js
+++ b/dataTables.rowsGroup.js
@@ -260,7 +260,7 @@ $(document).on('init.dt.rowsGroup', (e, settings) => {
 }(
     (typeof require === 'function')
         ? require('jQuery')
-        : window.jQuery,
+        : window.jQuery
 ));
 
 /*

--- a/dataTables.rowsGroup.js
+++ b/dataTables.rowsGroup.js
@@ -68,7 +68,7 @@ class RowsGroup {
         this.mergeCellsNeeded = false; // merge after init
         this.order = [];
         
-        dt.on('order.dt', () => {
+        dt.on('order.dt.rowsGroup', () => {
             if (!this.orderOverrideNow) {
                 this.orderOverrideNow = true;
                 this._updateOrderAndDraw();
@@ -77,32 +77,32 @@ class RowsGroup {
             }
         });
         
-        dt.on('preDraw.dt', () => {
+        dt.on('preDraw.dt.rowsGroup', () => {
             if (this.mergeCellsNeeded) {
                 this.mergeCellsNeeded = false;
                 this._mergeCells();
             }
         });
         
-        dt.on('column-visibility.dt', () => {
+        dt.on('column-visibility.dt.rowsGroup', () => {
             this.mergeCellsNeeded = true;
         });
 
-        dt.on('search.dt', () => {
+        dt.on('search.dt.rowsGroup', () => {
             // This might to increase the time to redraw while searching on tables
             //   with huge shown columns
             this.mergeCellsNeeded = true;
         });
 
-        dt.on('page.dt', () => {
+        dt.on('page.dt.rowsGroup', () => {
             this.mergeCellsNeeded = true;
         });
 
-        dt.on('length.dt', () => {
+        dt.on('length.dt.rowsGroup', () => {
             this.mergeCellsNeeded = true;
         });
 
-        dt.on('xhr.dt', () => {
+        dt.on('xhr.dt.rowsGroup', () => {
             this.mergeCellsNeeded = true;
         });
 
@@ -231,7 +231,7 @@ if ($.fn.DataTable) $.fn.DataTable.RowsGroup = RowsGroup;
 /* eslint-enable no-param-reassign */
 
 // Automatic initialisation listener
-$(document).on('init.dt', (e, settings) => {
+$(document).on('init.dt.rowsGroup', (e, settings) => {
     if (e.namespace !== 'dt') {
         return;
     }

--- a/dataTables.rowsGroup.js
+++ b/dataTables.rowsGroup.js
@@ -266,7 +266,11 @@ $(document).on( 'init.dt', function ( e, settings ) {
 	}
 } );
 
-}(jQuery));
+}(
+    (typeof require === 'function')
+        ? require('jQuery')
+        : window.jQuery,
+));
 
 /*
 

--- a/dataTables.rowsGroup.js
+++ b/dataTables.rowsGroup.js
@@ -237,8 +237,8 @@ RowsGroup.prototype = {
 };
 
 
-$.fn.dataTable.RowsGroup = RowsGroup;
-$.fn.DataTable.RowsGroup = RowsGroup;
+if ($.fn.dataTable) $.fn.dataTable.RowsGroup = RowsGroup;
+if ($.fn.DataTable) $.fn.DataTable.RowsGroup = RowsGroup;
 
 // Automatic initialisation listener
 $(document).on( 'init.dt', function ( e, settings ) {

--- a/example.html
+++ b/example.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+	<meta charset="utf-8">
 	<link rel="stylesheet" href="http://cdn.datatables.net/1.10.7/css/jquery.dataTables.min.css">
 
 	<script src="http://code.jquery.com/jquery-2.1.4.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "datatables-rowsgroup",
+  "version": "2.0.0",
+  "description": "Datatables plugin that groups rows (rowspan)",
+  "main": "dataTables.rowsGroup.js",
+  "scripts": {
+    "test": "eslint *.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ashl1/datatables-rowsgroup.git"
+  },
+  "author": "Alexey Shildyakov",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ashl1/datatables-rowsgroup/issues"
+  },
+  "homepage": "https://github.com/ashl1/datatables-rowsgroup#readme",
+  "dependencies": {
+    "jQuery": "^1.7.4"
+  },
+  "devDependencies": {
+    "eslint": "^4.6.1",
+    "eslint-config-airbnb": "^15.1.0",
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-jsx-a11y": "^5.1.1",
+    "eslint-plugin-react": "^7.3.0"
+  }
+}


### PR DESCRIPTION
Supersedes #11.

I used a simpler UMD-style function without AMD, because browserify/webpack don’t need that, and ESLint only works with a IIFE.

all commits are rather small, except for the ESLint style thing, so just look at them individually, please.

I also fixed a bug that occurs if e.g. `$.fn.dataTable` doesn’t exist (only `DataTable` with “D”)