### PR TITLE
merge cells containing complex values (objects, arrays)

### DIFF
--- a/dataTables.rowsGroup.js
+++ b/dataTables.rowsGroup.js
@@ -199,8 +199,18 @@ RowsGroup.prototype = {
 		var newSequenceRow = iStartRow,
 			iRow;
 		for (iRow = iStartRow + 1; iRow <= iFinishRow; ++iRow) {
+			//added to handle complex values (objects, arrays)
+			var curValue = null;
+			var nextValue = null;
+			if (typeof columnValues[iRow] === "object") {
+				curValue = JSON.stringify(columnValues[iRow]);
+				nextValue = JSON.stringify(columnValues[newSequenceRow]);
+			} else { 
+				curValue = columnValues[iRow];
+				nextValue = columnValues[newSequenceRow];
+			}
 			
-			if (columnValues[iRow] === columnValues[newSequenceRow]) {
+			if (curValue === nextValue) {
 				$(columnNodes[iRow]).hide()
 			} else {
 				$(columnNodes[newSequenceRow]).show()


### PR DESCRIPTION
Sometimes I don't have plain values in columns because I want to join values or inject custom classes or html blocks into che cell. If values are object or array, I do the check between stringified versions