### PR TITLE
Update dataTables.rowsGroup.js

### DIFF
--- a/dataTables.rowsGroup.js
+++ b/dataTables.rowsGroup.js
@@ -251,7 +251,7 @@ $(document).on( 'init.dt', function ( e, settings ) {
 	if ( settings.oInit.rowsGroup ||
 		 $.fn.dataTable.defaults.rowsGroup )
 	{
-		options = settings.oInit.rowsGroup?
+		var options = settings.oInit.rowsGroup?
 			settings.oInit.rowsGroup:
 			$.fn.dataTable.defaults.rowsGroup;
 		var rowsGroup = new RowsGroup( api, options );


### PR DESCRIPTION
Remove global scope from options variable as can cause Uncaught TypeError: Assignment to constant variable if "options" is used in other external libraries on the same page.