### PR TITLE
Uncaught ReferenceError: currentColumn is not defined

### DIFF
--- a/dataTables.rowsGroup.js
+++ b/dataTables.rowsGroup.js
@@ -190,7 +190,7 @@ RowsGroup.prototype = {
 	_mergeColumn: function(iStartRow, iFinishRow, columnsIndexes)
 	{
 		var columnsIndexesCopy = columnsIndexes.slice()
-		currentColumn = columnsIndexesCopy.shift()
+		var currentColumn = columnsIndexesCopy.shift()
 		currentColumn = this.table.column(currentColumn, ShowedDataSelectorModifier)
 		
 		var columnNodes = currentColumn.nodes()

--- a/dataTables.rowsGroup.js
+++ b/dataTables.rowsGroup.js
@@ -40,7 +40,7 @@
 
 (function($){
 
-ShowedDataSelectorModifier = {
+var ShowedDataSelectorModifier = {
 	order: 'current',
 	page: 'current',
 	search: 'applied',

--- a/dataTables.rowsGroup.js
+++ b/dataTables.rowsGroup.js
@@ -46,7 +46,7 @@ var ShowedDataSelectorModifier = {
 	search: 'applied',
 }
 
-GroupedColumnsOrderDir = 'asc';
+var GroupedColumnsOrderDir = 'asc';
 
 
 /*


### PR DESCRIPTION
Uncaught ReferenceError: currentColumn is not defined

		var currentColumn = columnsIndexesCopy.shift()
