### PR TITLE
Update dataTables.rowsGroup.js

### DIFF
--- a/dataTables.rowsGroup.js
+++ b/dataTables.rowsGroup.js
@@ -71,7 +71,7 @@ var RowsGroup = function ( dt, columnsForGrouping )
 		}
 	})
 	
-	dt.on('preDraw.dt', function ( e, settings) {
+	dt.on('draw.dt', function ( e, settings) {
 		if (self.mergeCellsNeeded) {
 			self.mergeCellsNeeded = false;
 			self._mergeCells()


### PR DESCRIPTION
Change on "preDraw.dt" event detection to on ''draw.dt" for rowspan properly on server-side loaded data.
It works on all cases server-side and non sevrer-side.